### PR TITLE
Generic batcher additions

### DIFF
--- a/src/NHibernate.Test/Ado/GenericBatchingBatcherFixture.cs
+++ b/src/NHibernate.Test/Ado/GenericBatchingBatcherFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Linq;
 using NHibernate.AdoNet;
 using NHibernate.Cfg;
@@ -59,6 +60,41 @@ namespace NHibernate.Test.Ado
 				Assert.That(4, Is.EqualTo(FindAllOccurrences(log, "Batch commands:")));
 			}
 			Cleanup();
+		}
+
+		// Demonstrates a 50% performance gain with SQL-Server, around 40% for PostgreSQL,
+		// around 15% for MySql, but around 200% performance loss for SQLite.
+		// (Tested with databases on same machine for all cases.)
+		[Theory, Explicit("This is a performance test, to be checked manually.")]
+		public void MassivePerformanceTest(bool batched)
+		{
+			if (batched)
+			{
+				// Bring down batch size to a reasonnable value, otherwise performances are worsen.
+				cfg.SetProperty(Environment.BatchSize, "50");
+			}
+			else
+			{
+				cfg.SetProperty(Environment.BatchStrategy, typeof(NonBatchingBatcherFactory).AssemblyQualifiedName);
+				cfg.Properties.Remove(Environment.BatchSize);
+			}
+			RebuildSessionFactory();
+
+			try
+			{
+				// Warm up
+				MassiveInsertUpdateDeleteTest();
+
+				var chrono = new Stopwatch();
+				chrono.Start();
+				MassiveInsertUpdateDeleteTest();
+				Console.WriteLine($"Elapsed time: {chrono.Elapsed}");
+			}
+			finally
+			{
+				Configure(cfg);
+				RebuildSessionFactory();
+			}
 		}
 
 		private void BatchInsert(int totalRecords)

--- a/src/NHibernate/AdoNet/IEmbeddedBatcherFactoryProvider.cs
+++ b/src/NHibernate/AdoNet/IEmbeddedBatcherFactoryProvider.cs
@@ -1,18 +1,18 @@
 namespace NHibernate.AdoNet
 {
 	/// <summary>
-	/// Provide the class of <see cref="IBatcherFactory"/> according to the configuration 
-	/// and the capabilities of the driver.
+	/// Provides a default <see cref="IBatcherFactory"/> class.
 	/// </summary>
 	/// <remarks>
-	/// By default, .Net doesn't have any batching capabilities, drivers that does have
-	/// batching support.
-	/// The BatcherFactory trough session-factory configuration section.
-	/// This interface was added in NHibernate for backdraw compatibility to have the ability
-	/// to specify a default <see cref="IBatcherFactory"/> for a specific <see cref="Driver.IDriver"/>.
+	/// This interface allows to specify a default <see cref="IBatcherFactory"/> for a specific
+	/// <see cref="Driver.IDriver"/>. The configuration setting <see cref="NHibernate.Cfg.Environment.BatchStrategy"/>
+	/// takes precedence over <c>BatcherFactoryClass</c>.
 	/// </remarks>
 	public interface IEmbeddedBatcherFactoryProvider
 	{
+		/// <summary>
+		/// The <see cref="IBatcherFactory"/> class type.
+		/// </summary>
 		System.Type BatcherFactoryClass { get;}
 	}
 }

--- a/src/NHibernate/Driver/NpgsqlDriver.cs
+++ b/src/NHibernate/Driver/NpgsqlDriver.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.Common;
+using NHibernate.AdoNet;
 
 namespace NHibernate.Driver
 {
@@ -24,7 +25,7 @@ namespace NHibernate.Driver
 	/// <a href="http://pgfoundry.org/projects/npgsql">http://pgfoundry.org/projects/npgsql</a>. 
 	/// </p>
 	/// </remarks>
-	public class NpgsqlDriver : ReflectionBasedDriver
+	public class NpgsqlDriver : ReflectionBasedDriver, IEmbeddedBatcherFactoryProvider
 	{
 		/// <summary>
 		/// Initializes a new instance of the <see cref="NpgsqlDriver"/> class.
@@ -92,5 +93,7 @@ namespace NHibernate.Driver
 		public override bool RequiresTimeSpanForTime => (DriverVersion?.Major ?? 3) >= 3;
 
 		public override bool HasDelayedDistributedTransactionCompletion => true;
+
+		System.Type IEmbeddedBatcherFactoryProvider.BatcherFactoryClass => typeof(GenericBatchingBatcherFactory);
 	}
 }

--- a/src/NHibernate/Driver/SqlClientDriver.cs
+++ b/src/NHibernate/Driver/SqlClientDriver.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+#if NETFX
 using System.Data.SqlClient;
+#endif
 using NHibernate.AdoNet;
 using NHibernate.Engine;
 using NHibernate.SqlTypes;
@@ -16,7 +18,7 @@ namespace NHibernate.Driver
 #if NETFX
 		: DriverBase, IEmbeddedBatcherFactoryProvider
 #else
-		: ReflectionBasedDriver
+		: ReflectionBasedDriver, IEmbeddedBatcherFactoryProvider
 #endif
 	{
 		public const int MaxSizeForAnsiClob = 2147483647; // int.MaxValue
@@ -50,6 +52,8 @@ namespace NHibernate.Driver
 			: base("System.Data.SqlClient", "System.Data.SqlClient.SqlConnection", "System.Data.SqlClient.SqlCommand")
 		{
 		}
+
+		System.Type IEmbeddedBatcherFactoryProvider.BatcherFactoryClass => typeof(GenericBatchingBatcherFactory);
 #else
 		/// <summary>
 		/// Creates an uninitialized <see cref="DbConnection" /> object for


### PR DESCRIPTION
Although I still consider nhibernate/nhibernate-core#1588 to be good enough for being merged in its current state, I propose some additions.

The first commit is meant to allow some basic measuring of the performance gain (or loss) resulting from the use of the generic batcher.

The second commit defines the generic batcher as the default batcher for drivers of databases benefiting of it. I have not done for MySql because it has already a specific batcher (but not defined as default), which is maybe available under .Net Core too.