### PR TITLE
Add doc and avoid a breaking change

### DIFF
--- a/doc/reference/modules/configuration.xml
+++ b/doc/reference/modules/configuration.xml
@@ -441,14 +441,6 @@ var session = sessions.OpenSession(conn);
             at runtime. All are optional and have reasonable default values.
         </para>
 
-        <para>
-            Some properties are system-level properties. They can only be set manually by setting static properties of
-            <literal>NHibernate.Cfg.Environment</literal> class or be defined in the
-            <literal>&lt;hibernate-configuration&gt;</literal> section of the application
-            configuration file. These properties cannot be set using <literal>Configuration.SetProperties</literal> or
-            the <literal>hibernate.cfg.xml</literal> configuration file.
-        </para>
-
         <table frame="topbot" id="configuration-optional-properties" revision="3">
             <title>NHibernate Configuration Properties</title>
             <tgroup cols="2">
@@ -511,53 +503,6 @@ var session = sessions.OpenSession(conn);
                             <para>
                                 <emphasis role="strong">eg.</emphasis> 
                                 recommended values between <literal>0</literal> and <literal>3</literal>
-                            </para>
-                        </entry>
-                    </row>
-                    <row>
-                        <entry>
-                            <literal>use_reflection_optimizer</literal>
-                        </entry>
-                        <entry>
-                            Enables use of a runtime-generated class to set or get properties of an entity
-                            or component instead of using runtime reflection. This is a system-level property.
-                            The use of the reflection optimizer inflicts a certain startup cost on the
-                            application but should lead to better performance in the long run.
-                            Defaults to <literal>true</literal>.
-                            <para>
-                                You can not set this property in <literal>hibernate.cfg.xml</literal>, but only
-                                in <literal>&lt;hibernate-configuration&gt;</literal> section of the application
-                                configuration file or by code by setting
-                                <literal>NHibernate.Cfg.Environment.UseReflectionOptimizer</literal>
-                                before creating any <literal>NHibernate.Cfg.Configuration</literal> instance.
-                            </para>
-                            <para>
-                                <emphasis role="strong">eg.</emphasis> 
-                                <literal>true</literal> | <literal>false</literal>
-                            </para>
-                        </entry>
-                    </row>
-                    <row>
-                        <entry>
-                            <literal>bytecode.provider</literal>
-                        </entry>
-                        <entry>
-                            Specifies the bytecode provider to use to optimize the use of reflection in NHibernate.
-                            This is a system-level property.
-                            Use <literal>null</literal> to disable the optimization completely, <literal>lcg</literal>
-                            to use built-in lightweight code generation, or the class name of a custom
-                            <literal>IBytecodeProvider</literal> implementation. Defaults to <literal>lcg</literal>.
-                            <para>
-                                You can not set this property in <literal>hibernate.cfg.xml</literal>, but only
-                                in <literal>&lt;hibernate-configuration&gt;</literal> section of the application
-                                configuration file or by code by setting
-                                <literal>NHibernate.Cfg.Environment.BytecodeProvider</literal>
-                                before creating any <literal>NHibernate.Cfg.Configuration</literal> instance.
-                            </para>
-                            <para>
-                                <emphasis role="strong">eg.</emphasis>
-                                <literal>null</literal> | <literal>lcg</literal> |
-                                <literal>classname.of.BytecodeProvider, assembly</literal>
                             </para>
                         </entry>
                     </row>
@@ -1464,6 +1409,95 @@ in the parameter binding.</programlisting>
             <para>
                 would allow you to rename the SQL <literal>LOWER</literal> function.
             </para>
+
+        </sect2>
+
+        <sect2 id="configuration-optional-systemlevel">
+            <title>System level optional properties</title>
+
+            <para>
+                Some properties are system-level properties. They can only be set manually by setting static
+                properties of <literal>NHibernate.Cfg.Environment</literal> class or be defined in the
+                <literal>&lt;hibernate-configuration&gt;</literal> section of the application configuration
+                file, as direct sub-elements. These properties can neither be set using
+                <literal>Configuration.SetProperties</literal> or the <literal>hibernate.cfg.xml</literal>
+                configuration file, nor be set as <literal>&lt;session-factory&gt;</literal> properties.
+            </para>
+
+            <table frame="topbot" id="configuration-systemlevel-properties">
+                <title>NHibernate system level properties</title>
+                <tgroup cols="2">
+                    <colspec colname="c1" colwidth="1*"/>
+                    <colspec colname="c2" colwidth="1*"/>
+                    <thead>
+                        <row>
+                            <entry>Property name</entry>
+                            <entry>Purpose</entry>
+                        </row>
+                    </thead>
+                    <tbody>
+                        <row>
+                            <entry>
+                                <literal>bytecode-provider</literal>
+                            </entry>
+                            <entry>
+                                <para>
+                                    Specifies the bytecode provider to use to optimize the use of reflection in NHibernate.
+                                    Use <literal>null</literal> to disable the optimization completely, <literal>lcg</literal>
+                                    to use built-in lightweight code generation, or the assembly qualified class name of a custom
+                                    <literal>IBytecodeProvider</literal> implementation. Defaults to <literal>lcg</literal>.
+                                </para>
+                                <programlisting><![CDATA[<bytecode-provider
+    type="lcg|null|className" />]]></programlisting>
+                                <para>
+                                    You can also set this property by code by setting
+                                    <literal>NHibernate.Cfg.Environment.BytecodeProvider</literal>
+                                    before creating any <literal>NHibernate.Cfg.Configuration</literal> instance.
+                                </para>
+                            </entry>
+                        </row>
+                        <row>
+                            <entry>
+                                <literal>objects-factory</literal>
+                            </entry>
+                            <entry>
+                                <para>
+                                    Specifies a custom objects factory to use for instantiating NHibernate dependencies.
+                                    Use the assembly qualified class name of a custom <literal>IObjectsFactory</literal>
+                                    implementation.
+                                </para>
+                                <programlisting><![CDATA[<bytecode-provider
+    type="className" />]]></programlisting>
+                                <para>
+                                    You can also set this property by code by setting
+                                    <literal>NHibernate.Cfg.Environment.ObjectsFactory</literal>
+                                    before creating any <literal>NHibernate.Cfg.Configuration</literal> instance.
+                                </para>
+                            </entry>
+                        </row>
+                        <row>
+                            <entry>
+                                <literal>reflection-optimizer</literal>
+                            </entry>
+                            <entry>
+                                <para>
+                                    Enables use of a runtime-generated class to set or get properties of an entity
+                                    or component instead of using runtime reflection. The use of the reflection
+                                    optimizer inflicts a certain startup cost on the application but should lead to
+                                    better performance in the long run. Defaults to <literal>true</literal>.
+                                </para>
+                                <programlisting><![CDATA[<reflection-optimizer
+    use="true|false"/>]]></programlisting>
+                                <para>
+                                    You can also set this property by code by setting
+                                    <literal>NHibernate.Cfg.Environment.UseReflectionOptimizer</literal>
+                                    before creating any <literal>NHibernate.Cfg.Configuration</literal> instance.
+                                </para>
+                            </entry>
+                        </row>
+                    </tbody>
+                </tgroup>
+            </table>
 
         </sect2>
 

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -378,7 +378,7 @@ namespace NHibernate.Cfg
 		/// The bytecode provider to use.
 		/// </summary>
 		/// <remarks>
-		/// This property is read from the <c>&lt;nhibernate&gt;</c> section
+		/// This property is read from the <c>&lt;hibernate-configuration&gt;</c> section
 		/// of the application configuration file by default. Since it is not
 		/// always convenient to configure NHibernate through the application
 		/// configuration file, it is also possible to set the property value
@@ -395,6 +395,11 @@ namespace NHibernate.Cfg
 		/// NHibernate's object instantiator.
 		/// </summary>
 		/// <remarks>
+		/// This property is read from the <c>&lt;hibernate-configuration&gt;</c> section
+		/// of the application configuration file by default. Since it is not
+		/// always convenient to configure NHibernate through the application
+		/// configuration file, it is also possible to set the property value
+		/// manually.
 		/// This should only be set before a configuration object
 		/// is created, otherwise the change may not take effect.
 		/// For entities see <see cref="IReflectionOptimizer"/> and its implementations.
@@ -405,7 +410,7 @@ namespace NHibernate.Cfg
 		/// Whether to enable the use of reflection optimizer
 		/// </summary>
 		/// <remarks>
-		/// This property is read from the <c>&lt;nhibernate&gt;</c> section
+		/// This property is read from the <c>&lt;hibernate-configuration&gt;</c> section
 		/// of the application configuration file by default. Since it is not
 		/// always convenient to configure NHibernate through the application
 		/// configuration file, it is also possible to set the property value

--- a/src/NHibernate/Cfg/Environment.cs
+++ b/src/NHibernate/Cfg/Environment.cs
@@ -388,7 +388,16 @@ namespace NHibernate.Cfg
 		public static IBytecodeProvider BytecodeProvider
 		{
 			get { return BytecodeProviderInstance; }
-			set { BytecodeProviderInstance = value; }
+			set
+			{
+				BytecodeProviderInstance = value;
+				// 6.0 TODO: remove following code.
+#pragma warning disable 618
+				var objectsFactory = BytecodeProviderInstance.ObjectsFactory;
+#pragma warning restore 618
+				if (objectsFactory != null)
+					ObjectsFactory = objectsFactory;
+			}
 		}
 
 		/// <summary>
@@ -450,8 +459,12 @@ namespace NHibernate.Cfg
 			var typeAssemblyQualifiedName = PropertiesHelper.GetString(PropertyObjectsFactory, properties, null);
 			if (typeAssemblyQualifiedName == null)
 			{
-				log.Info("Objects factory class : {0}", typeof(ActivatorObjectsFactory));
-				return new ActivatorObjectsFactory();
+				// 6.0 TODO: use default value of ObjectsFactory property
+#pragma warning disable 618
+				var objectsFactory = BytecodeProvider.ObjectsFactory ?? ObjectsFactory;
+#pragma warning restore 618
+				log.Info("Objects factory class : {0}", objectsFactory.GetType());
+				return objectsFactory;
 			}
 			log.Info("Custom objects factory class : {0}", typeAssemblyQualifiedName);
 			return CreateCustomObjectsFactory(typeAssemblyQualifiedName);


### PR DESCRIPTION
First commit adds doc. I also thought it was time to move these settings to their own section, with their element tag name instead of the property name which is unusable.

Second commit avoids a breaking change. I have not done the "use objects factory for creating byte-code provider" part, since both are system level properties. It would create a cumbersome behavior in case someone set the objects factory by code: the byte-code provider would already have been resolved a first time by the static constructor. And we would need to re-resolve it just in case?

I am doing this as a PR as I am denied pushing on your branch.